### PR TITLE
Tratamento de exceções de logging fora de escopo padrão

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-observability",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lib que centraliza as apis de observabilidade da Squid e às inicializa conforme necessidade do usuário",
   "main": "squid_observability.js",
   "scripts": {


### PR DESCRIPTION
Atualiza observability para conter o bugfix presente no [PR #7 da squid-logger](https://github.com/squidit/squid-logger-nodejs/pull/7)