### PR TITLE
Simplificação de tipagem de bibliotecas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-observability",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Lib que centraliza as apis de observabilidade da Squid e às inicializa conforme necessidade do usuário",
   "main": "squid_observability.js",
   "scripts": {

--- a/squid_observability.d.ts
+++ b/squid_observability.d.ts
@@ -5,16 +5,9 @@
 /// <reference path="libraries/squid-error-nodejs/squid_error.d.ts"/>
 
 declare module 'squid-observability' {
-  import * as SquidTracerType from 'squid-tracer';
-  import * as SquidMetricsType from 'squid-metrics';
-  import * as SquidLoggerType from 'squid-logger';
-  import { SquidObservabilityConfigs as SquidObservabilityConfigsType} from 'squid-observability-configs';
-  import { SquidError as SquidErrorType, SquidHttpError as SquidHttpErrorType } from 'squid_error';
-
-  const SquidTracer: typeof SquidTracerType;
-  const SquidMetrics: typeof SquidMetricsType;
-  const SquidLogger: typeof SquidLoggerType;
-  const SquidObservabilityConfigs: typeof SquidObservabilityConfigsType;
-  const SquidError: typeof SquidErrorType;
-  const SquidHttpError: typeof SquidHttpErrorType;
+  export { SquidError, SquidHttpError } from 'squid_error';
+  export { SquidObservabilityConfigs } from 'squid-observability-configs';
+  export * as SquidLogger from 'squid-logger';
+  export * as SquidMetrics from 'squid-metrics';
+  export * as SquidTracer from 'squid-tracer';
 }


### PR DESCRIPTION
Foi feita uma simplificação no arquivo de tipagem das bibliotecas utilizadas pela observability, com o intuito de resolver um problema de tipagem onde a utilização do `SquidError.Create` retornava um `SquidError` que não era compatível com a própria classe `SquidError`, fazendo com que o TypeScript LSP se confundisse e acusasse problemas na tipagem.

O novo formato mais corretamente explicita a tipagem das bibliotecas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized module exports for improved structure and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->