### PR TITLE
Correção de tipagem de SquidHttpError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-observability",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Lib que centraliza as apis de observabilidade da Squid e às inicializa conforme necessidade do usuário",
   "main": "squid_observability.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes a small change to the `libraries/squid-error-nodejs` submodule. The change updates the submodule commit reference to point to a new commit.

* [`libraries/squid-error-nodejs`](diffhunk://#diff-ee62d40717e4abe2733d9541dabc4c73a1203807308365334f02d8d5332627a3L1-R1): Updated submodule commit reference to `b0ec147795a86b8c017cbe47e878c305e7e73477`.